### PR TITLE
 Tool Installation

### DIFF
--- a/Day0  /Tool Installation
+++ b/Day0  /Tool Installation
@@ -1,5 +1,2 @@
-Tool Installation
-Memory used for ubuntu tool installation
-6GB RAM, 50 GB HDD 
-Ubuntu 20.04+ 
-4vCPU
+
+


### PR DESCRIPTION
**Memory used for ubuntu tool installation**

6GB RAM, 50 GB HDD 
Ubuntu 20.04+ 
4vCPU
